### PR TITLE
Add ID to dialog

### DIFF
--- a/src/aiChat/index.tsx
+++ b/src/aiChat/index.tsx
@@ -162,6 +162,7 @@ export function Dialog({
 
   return (
     <div
+      id="convex-ai-chat"
       className={
         (isOpen ? "fixed" : "hidden") +
         " rounded-xl flex flex-col bg-white dark:bg-black text-black dark:text-white " +


### PR DESCRIPTION
Adds a unique ID, `convex-ai-chat`, to the chat window element:

![image](https://github.com/get-convex/convex-ai-chat/assets/1382445/a182a70c-e2ab-4ace-8169-cd744198bec5)

This allows consuming applications to target and customize the chat window’s styles more effectively, such as adjusting the z-index to ensure it sits above other page content:

```
#convex-ai-chat {
  z-index: 1000; /* Customize as needed */
}
```

Another approach would be to add an optional `className` prop, which could be passed through to the same element, and this would allow for classes to be applied directly. I've opted for the simplest method to start with, as we can always add that later if requested.